### PR TITLE
Fix issue that proxy may use expired authorization from request.

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func proxy(c *gin.Context) {
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Keep-Alive", "timeout=360")
 	request.Header.Set("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36")
-	request.Header.Set("Authorization", c.Request.Header.Get("Authorization"))
+	request.Header.Set("Authorization", "Bearer "+access_token)
 	if c.Request.Header.Get("Puid") == "" {
 		request.AddCookie(
 			&http.Cookie{


### PR DESCRIPTION
In the proxy mode, proxy handler use the Authorization header from the client. 
Some clients may keep an expired authorization token which caused 401 error. 

With this change we always use the specified ACCESS_TOKEN.